### PR TITLE
Remove Oathplate shards from mapping

### DIFF
--- a/drop-mapping.txt
+++ b/drop-mapping.txt
@@ -227,4 +227,3 @@ Yama,30750,Yama,Oathplate helm
 Yama,30753,Yama,Oathplate chest
 Yama,30756,Yama,Oathplate legs
 Yama,30759,Yama,Soulflame horn
-Yama,30765,Yama,Oathplate shards


### PR DESCRIPTION
The amount of submissions is a bit too high, remove to clean up + it's not that interesting of a drop anyways.